### PR TITLE
Don't stringify all attribute values before encoding via json.Marshal

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -59,10 +59,23 @@ func attrToDatadogLog(base string, attrs []slog.Attr, log *map[string]any) {
 
 		if attr.Key == "user" && kind == slog.KindGroup {
 			attrToDatadogLog("usr.", v.Group(), log)
-		} else if kind == slog.KindGroup {
-			attrToDatadogLog(base+k+".", v.Group(), log)
 		} else {
-			(*log)[base+k] = slogcommon.ValueToString(v)
+			switch kind {
+			case slog.KindGroup:
+				attrToDatadogLog(base+k+".", v.Group(), log)
+			case slog.KindBool:
+				(*log)[base+k] = v.Bool()
+			case slog.KindFloat64:
+				(*log)[base+k] = v.Float64()
+			case slog.KindInt64:
+				(*log)[base+k] = v.Int64()
+			case slog.KindString:
+				(*log)[base+k] = v.String()
+			case slog.KindAny:
+				(*log)[base+k] = v.Any()
+			default:
+				(*log)[base+k] = slogcommon.ValueToString(v)
+			}
 		}
 	}
 }

--- a/converter_test.go
+++ b/converter_test.go
@@ -1,0 +1,98 @@
+package slogdatadog
+
+import (
+	"log/slog"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var testLogTime = time.Now()
+
+func TestDefaultConverter(t *testing.T) {
+	type ExampleStruct struct {
+		ExampleField1 string
+		ExampleField2 string
+	}
+
+	type args struct {
+		addSource   bool
+		replaceAttr func(groups []string, a slog.Attr) slog.Attr
+		loggerAttr  []slog.Attr
+		groups      []string
+		record      *slog.Record
+	}
+
+	type testCase struct {
+		args     args
+		expected map[string]any
+	}
+
+	cases := []testCase{
+		// Struct values are passed through unstringified.
+		{
+			args: args{
+				false,
+				dontReplaceAnyAttrs,
+				[]slog.Attr{
+					{Key: "Attr1", Value: slog.StringValue("foo")},
+					{Key: "Attr2", Value: slog.Float64Value(888.88)},
+					{Key: "Attr3", Value: slog.AnyValue(ExampleStruct{"foo", "bar"})},
+				},
+				nil,
+				&slog.Record{Message: "test", Time: testLogTime},
+			},
+			expected: map[string]any{
+				"level":   "INFO",
+				"Attr1":   "foo",
+				"Attr2":   888.88,
+				"Attr3":   ExampleStruct{"foo", "bar"},
+				"message": "test",
+			},
+		},
+		// replaceAttr function is called and replaces attributes
+		{
+			args: args{
+				false,
+				replaceAttrValueWith("Attr1", "baz"),
+				[]slog.Attr{{Key: "Attr1", Value: slog.StringValue("foo")},
+					{Key: "Attr2", Value: slog.AnyValue(ExampleStruct{"foo", "bar"})}},
+				nil,
+				&slog.Record{Message: "test", Time: testLogTime},
+			},
+			expected: map[string]any{
+				"level":   "INFO",
+				"Attr1":   "baz",
+				"Attr2":   ExampleStruct{"foo", "bar"},
+				"message": "test",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		r := DefaultConverter(c.args.addSource, c.args.replaceAttr, c.args.loggerAttr, c.args.groups, c.args.record)
+		addCommonExpectedAttrs(c.expected)
+		if !reflect.DeepEqual(r, c.expected) {
+			t.Errorf("Expected\n  %+v\nGot\n  %+v\n", c.expected, r)
+		}
+	}
+}
+
+func addCommonExpectedAttrs(m map[string]any) {
+	m["@timestamp"] = testLogTime.UTC()
+	m["logger.name"] = "samber/slog-datadog"
+	m["logger.version"] = "VERSION" // won't be replaced in test build
+}
+
+func replaceAttrValueWith(name, replacement string) func(groups []string, a slog.Attr) slog.Attr {
+	return func(groups []string, a slog.Attr) slog.Attr {
+		if a.Key == name {
+			a.Value = slog.StringValue(replacement)
+		}
+		return a
+	}
+}
+
+func dontReplaceAnyAttrs(groups []string, a slog.Attr) slog.Attr {
+	return a
+}

--- a/handler.go
+++ b/handler.go
@@ -92,10 +92,7 @@ func (h *DatadogHandler) Enabled(_ context.Context, level slog.Level) bool {
 }
 
 func (h *DatadogHandler) Handle(ctx context.Context, record slog.Record) error {
-	fromContext := slogcommon.ContextExtractor(ctx, h.option.AttrFromContext)
-	log := h.option.Converter(h.option.AddSource, h.option.ReplaceAttr, append(h.attrs, fromContext...), h.groups, &record)
-
-	bytes, err := h.option.Marshaler(log)
+	bytes, err := handle(h, ctx, record)
 	if err != nil {
 		return err
 	}
@@ -107,6 +104,13 @@ func (h *DatadogHandler) Handle(ctx context.Context, record slog.Record) error {
 	}()
 
 	return nil
+}
+
+func handle(h *DatadogHandler, ctx context.Context, record slog.Record) ([]byte, error) {
+	fromContext := slogcommon.ContextExtractor(ctx, h.option.AttrFromContext)
+	log := h.option.Converter(h.option.AddSource, h.option.ReplaceAttr, append(h.attrs, fromContext...), h.groups, &record)
+
+	return h.option.Marshaler(log)
 }
 
 func (h *DatadogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/handler_test.go
+++ b/handler_test.go
@@ -32,7 +32,7 @@ func TestArgFormatting(t *testing.T) {
 	bytes, err := handle(ddh, context.Background(), r)
 
 	if err != nil {
-		t.Errorf("handle() error = %v", err)
+		t.Fatalf("handle() error = %v", err)
 	}
 
 	var data map[string]any
@@ -54,6 +54,6 @@ func TestArgFormatting(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, data) {
-		t.Errorf("Expected\n  %v\nGot\n  %v", expected, data)
+		t.Fatalf("Expected\n  %v\nGot\n  %v", expected, data)
 	}
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,59 @@
+package slogdatadog
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+)
+
+func TestArgFormatting(t *testing.T) {
+	type ExampleStruct struct {
+		ExampleField1 string
+		ExampleField2 string
+	}
+
+	var r slog.Record
+	r.Add(
+		"Attr1", slog.AnyValue(ExampleStruct{ExampleField1: "foo", ExampleField2: "bar"}),
+		"Attr2", slog.StringValue("foo"),
+		"Attr3", slog.IntValue(999),
+		"Attr4", slog.Float64Value(999.99),
+	)
+	r.Message = "test"
+
+	h := Option{
+		Client: &datadog.APIClient{},
+	}.NewDatadogHandler()
+	ddh := h.(*DatadogHandler)
+	bytes, err := handle(ddh, context.Background(), r)
+
+	if err != nil {
+		t.Errorf("handle() error = %v", err)
+	}
+
+	var data map[string]any
+	err = json.Unmarshal(bytes, &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]any{
+		"@timestamp":     "0001-01-01T00:00:00Z",
+		"level":          "INFO",
+		"logger.name":    "samber/slog-datadog",
+		"logger.version": "VERSION", // won't be replaced in test build
+		"Attr1":          map[string]any{"ExampleField1": "foo", "ExampleField2": "bar"},
+		"Attr2":          "foo",
+		"Attr3":          999.0,
+		"Attr4":          999.99,
+		"message":        "test",
+	}
+
+	if !reflect.DeepEqual(expected, data) {
+		t.Errorf("Expected\n  %v\nGot\n  %v", expected, data)
+	}
+}


### PR DESCRIPTION
Hey samber. Thanks for this library – it has been very useful.

This is an attempt to fix [this issue](https://github.com/samber/slog-datadog/issues/3#issuecomment-2364177963).

In the current implementation, a call such as 

```Go
type Foo struct {
  Bar string
  Amp string
}
slog.Info("Log message", "foo", Foo{Bar: "bar", Amp: "amp"})
```

will send JSON like

```
{..., "foo": "{Bar:bar Amp:amp}"}
```

where the `Foo` value has been stringified prior to JSON serialization. Similarly, integers and floats will appear as strings in the JSON sent to datadog.

This PR passes through types which have a reasonable JSON representation without converting them to strings first. The `slog.Info` call above now sends JSON like

```
{..., "foo": {"Bar": "bar", "Amp": "amp"}}
```

I've attempted to add tests which illustrate the fix and which break if the 'bug fix' commit is reverted. The test for the `Handler` is not ideal as it tests a private function, but I think it's a reasonable alternative to adding some quite complex mocking.