### PR TITLE
Option to override DD `Source`

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -28,6 +28,8 @@ type Option struct {
 
 	// source parameters
 	Service    string
+	// source (optional): Allows overriding the `source` field sent to DD. defaulted to version.name
+	Source     string
 	Hostname   string
 	GlobalTags map[string]string
 
@@ -142,9 +144,14 @@ func (h *DatadogHandler) send(message string) error {
 		}
 	}
 
+	source := h.option.Source
+	if source == "" {
+		source = name
+	}
+	
 	body := []datadogV2.HTTPLogItem{
 		{
-			Ddsource: datadog.PtrString(name),
+			Ddsource: datadog.PtrString(source),
 			Hostname: datadog.PtrString(h.option.Hostname),
 			Service:  datadog.PtrString(h.option.Service),
 			Ddtags:   datadog.PtrString(strings.Join(tags, ",")),


### PR DESCRIPTION
The Datadog (DD) field `source` is hardcoded to `samber/slog-datadog`, but does not allow the developer to override it if required.

In DD logs, the `source` field is considered a "Core" facet, so there are limit options to change/remove it.

We use the `source` for the Environment value (dev, staging, prod) - so it would be nice to have our Golang app conform to this like our other apps.